### PR TITLE
Harden the OpenQASM 2.0 parser against malformed input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 - Updated third party library [fmt](https://github.com/fmtlib/fmt) to version
   11.1.2
 - Fixed MSVC compiling issues on Windows
+- Hardened the OpenQASM 2.0 parser against malformed input: out-of-range
+  numeric literals, deeply nested expressions, unterminated string literals at
+  end of file, and token kind/value mismatches now yield a parse error instead
+  of aborting or hanging the process
 
 # Version 3.5 - 8 March 2024
 

--- a/qasmtools/include/qasmtools/parser/lexer.hpp
+++ b/qasmtools/include/qasmtools/parser/lexer.hpp
@@ -165,11 +165,17 @@ class Lexer {
             }
         }
 
-        if (integral) {
-            return Token(tok_start, Token::Kind::nninteger, str,
-                         std::stoi(str));
-        } else {
-            return Token(tok_start, Token::Kind::real, str, std::stof(str));
+        try {
+            if (integral) {
+                return Token(tok_start, Token::Kind::nninteger, str,
+                             std::stoi(str));
+            } else {
+                return Token(tok_start, Token::Kind::real, str, std::stof(str));
+            }
+        } catch (const std::out_of_range&) {
+            std::cerr << "Lexical error at " << tok_start
+                      << ": numeric literal out of range\n";
+            return Token(tok_start, Token::Kind::error, str);
         }
     }
 
@@ -213,7 +219,7 @@ class Lexer {
         str.reserve(64); // Reserve space to avoid reallocation
 
         while (buf_->peek() != '"' && buf_->peek() != '\n' &&
-               buf_->peek() != '\r') {
+               buf_->peek() != '\r' && buf_->peek() != EOF) {
             str.push_back(buf_->peek());
             skip_char();
         }

--- a/qasmtools/include/qasmtools/parser/parser.hpp
+++ b/qasmtools/include/qasmtools/parser/parser.hpp
@@ -70,6 +70,10 @@ class Parser {
     Token current_token_;         ///< current token
     int bits_ = 0;                ///< number of bits
     int qubits_ = 0;              ///< number of qubits
+    int expr_depth_ = 0;          ///< current expression-parsing recursion depth
+    /// Cap on expression nesting; bounds recursion to prevent stack overflow
+    /// on adversarial input (e.g. deeply nested parentheses).
+    static constexpr int MAX_EXPR_DEPTH = 1000;
 #ifdef EXPR_GMP
     bool use_gmp_ = false; ///< whether to use gmp to parse reals
 #endif                     /* EXPR_GMP */
@@ -650,6 +654,20 @@ class Parser {
      * \return Unique pointer to an expression object
      */
     ast::ptr<ast::Expr> parse_exp(int min_precedence = 1) {
+        struct DepthGuard {
+            int& d;
+            explicit DepthGuard(int& d_) : d(d_) { ++d; }
+            ~DepthGuard() { --d; }
+        } depth_guard{expr_depth_};
+        if (expr_depth_ > MAX_EXPR_DEPTH) {
+            error_ = true;
+            if (!supress_errors_) {
+                std::cerr << current_token_.position()
+                          << ": expression nesting exceeds maximum depth\n";
+            }
+            throw ParseError();
+        }
+
         auto pos = current_token_.position();
 
         auto lexp = parse_atom();

--- a/qasmtools/include/qasmtools/parser/token.hpp
+++ b/qasmtools/include/qasmtools/parser/token.hpp
@@ -294,7 +294,13 @@ class Token {
      *
      * \return The value of the token as an integer
      */
-    int as_int() const { return std::get<int>(value_); }
+    int as_int() const {
+        // Total accessor: a kind/value mismatch (e.g. a token returned by a
+        // failed expect_and_consume_token) must not throw std::bad_variant_access
+        // and abort the host; the parser's error_ flag already records the error.
+        auto* p = std::get_if<int>(&value_);
+        return p ? *p : 0;
+    }
 
     /**
      * \brief Get the floating point value
@@ -303,7 +309,10 @@ class Token {
      *
      * \return The value of the token as a floating point number
      */
-    double as_real() const { return std::get<double>(value_); }
+    double as_real() const {
+        auto* p = std::get_if<double>(&value_);
+        return p ? *p : 0.0;
+    }
 
     /**
      * \brief Get the string value
@@ -312,7 +321,10 @@ class Token {
      *
      * \return The value of the token as a string
      */
-    std::string as_string() const { return std::get<std::string>(value_); }
+    std::string as_string() const {
+        auto* p = std::get_if<std::string>(&value_);
+        return p ? *p : std::string();
+    }
 
     /**
      * \brief Return the position of the token


### PR DESCRIPTION
# Harden the OpenQASM 2.0 parser against malformed input

## Summary

The `qasmtools` recursive-descent parser can be made to abort or hang the host
process on malformed OpenQASM input reachable through the public entry point
`parse_string` (and therefore `pystaq.parse_str`, the `staq` CLI, and any project
embedding the header-only parser). This PR closes five such cases without changing
behaviour on valid input.

| Input | Before | Cause |
|-------|--------|-------|
| integer literal `> INT_MAX` | `abort()` | uncaught `std::out_of_range` from `std::stoi` |
| real literal out of `float` range (`1e99999999`) | `abort()` | uncaught `std::out_of_range` from `std::stof` |
| deeply nested `(((…)))` in an expression | SIGSEGV | unbounded recursion in `parse_exp`/`parse_atom` |
| unterminated string at EOF (`include "…`) | infinite loop | `lex_string` loop condition omits EOF |
| wrong token where an id/int is expected (`qreg 5[2];`) | `abort()` | `std::bad_variant_access` from `as_string()/as_int()` on a mismatched token |

The first, second and fifth cases matter beyond a CLI: they raise C++ exceptions
that are **not** the parser's documented `ParseError`, so a caller catching only
`ParseError` still aborts. The recursion and infinite-loop cases bypass exception
handling entirely (including pybind11's translation), so a `pystaq`-based service
crashes or hangs too.

## Changes

- **`lexer.hpp`** — wrap `std::stoi`/`std::stof` in `try/catch (std::out_of_range)`
  and return a `Token::Kind::error` (mirroring the existing unmatched-quote path);
  add `&& buf_->peek() != EOF` to the `lex_string` loop (the same guard already used
  by the comment lexer).
- **`parser.hpp`** — bound expression-parsing recursion with an RAII depth guard
  (`MAX_EXPR_DEPTH = 1000`); on overflow, set the error flag and raise `ParseError`.
- **`token.hpp`** — make `as_int`/`as_real`/`as_string` total using `std::get_if`,
  returning a default on a kind/value mismatch instead of throwing. The parser's
  `error_` flag is set independently, so malformed input still ends in `ParseError`.
- **`CHANGES.md`** — one line under `# Pre-release`.

## Testing

- Each of the five inputs above now returns gracefully (`ParseError` or a clean
  parse) instead of aborting/hanging.
- All 82 sample `.qasm` files under `misc/` and `pystaq/` parse identically before
  and after this change — no behavioural change on valid input.

Total diff: 4 files, +49/-9.
